### PR TITLE
Alias `jq` to `yq`

### DIFF
--- a/bash.sh
+++ b/bash.sh
@@ -120,3 +120,5 @@ bind_pdfs () {
     pdftk $files cat output $tmp
     mv $tmp $out
 }
+
+alias jq=yq


### PR DESCRIPTION
Motivation: All valid JSON is also valid YAML.